### PR TITLE
修正订单列表查询接口响应类中商品编码类型错误

### DIFF
--- a/src/PddOpenSdk/Models/Response/Order/GetOrderListResponse.cs
+++ b/src/PddOpenSdk/Models/Response/Order/GetOrderListResponse.cs
@@ -704,7 +704,7 @@ public partial class GetOrderListResponse : PddResponseModel
                 /// 商品编码
                 /// </summary>
                 [JsonPropertyName("goods_id")]
-                public string GoodsId { get; set; }
+                public long? GoodsId { get; set; }
 
                 /// <summary>
                 /// 商品图片
@@ -746,7 +746,7 @@ public partial class GetOrderListResponse : PddResponseModel
                 /// 商品sku编码
                 /// </summary>
                 [JsonPropertyName("sku_id")]
-                public string SkuId { get; set; }
+                public long? SkuId { get; set; }
 
             }
             public partial class OrderDepotInfoResponse : PddResponseModel


### PR DESCRIPTION
可能是由于拼多多更新了接口但未更新[接口文档](https://open.pinduoduo.com/application/document/api?id=pdd.order.list.get)，目前订单商品列表中的goods_id和sku_id是long类型，导致OrderApi.GetOrderListAsync接口会报

> The JSON value could not be converted to System.String. Path: $.order_list_get_response.order_list[0].item_list[0].goods_id

我修改了这两个字段类型，可以正确映射结果。